### PR TITLE
Speed up app launch via background emoji loading, progressive UI rendering, and loading state 🚀

### DIFF
--- a/src/Picker.py
+++ b/src/Picker.py
@@ -77,8 +77,8 @@ class Picker(Gtk.ApplicationWindow):
         self.viewport_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, css_classes=['viewport'], vexpand=True)
 
         self.list_tip_revealer = Gtk.Revealer(
-            reveal_child=False, 
-            transition_type=Gtk.RevealerTransitionType.NONE, 
+            reveal_child=False,
+            transition_type=Gtk.RevealerTransitionType.NONE,
             css_classes=['solid-overlay'],
             visible=False
             # valign=Gtk.Align.START,
@@ -86,7 +86,7 @@ class Picker(Gtk.ApplicationWindow):
 
         self.list_tip_label = Gtk.Label(
             label= _("Whoa, it's still empty! \nYour most used emojis will show up here\n"),
-            css_classes=['dim-label'], 
+            css_classes=['dim-label'],
             justify=Gtk.Justification.CENTER
         )
 
@@ -96,7 +96,7 @@ class Picker(Gtk.ApplicationWindow):
 
         select_buffer_button = Gtk.Button(icon_name='arrow2-right-symbolic', valign=Gtk.Align.CENTER)
         select_buffer_button.connect('clicked', lambda w: self.copy_and_quit())
-        
+
         pop_buffer_btn = Gtk.Button(icon_name='smile-entry-clear-symbolic', valign=Gtk.Align.CENTER, css_classes=['flat'])
         pop_buffer_btn.connect('clicked', lambda w: self.deselect_last_selected_emoji())
 
@@ -104,9 +104,9 @@ class Picker(Gtk.ApplicationWindow):
         [select_buffer_container.append(w) for w in [self.select_buffer_label, pop_buffer_btn, select_buffer_button]]
 
         self.select_buffer_revealer = Gtk.Revealer(
-            reveal_child=False, 
+            reveal_child=False,
             css_classes=['solid-overlay'],
-            child=select_buffer_container, 
+            child=select_buffer_container,
             valign=Gtk.Align.END
         )
 
@@ -127,9 +127,9 @@ class Picker(Gtk.ApplicationWindow):
         self.category_picker = self.create_category_picker()
 
         scrolled_emoji_window = Gtk.ScrolledWindow(
-            min_content_height=EMOJI_LIST_MIN_HEIGHT, 
-            propagate_natural_height=True, 
-            propagate_natural_width=True, 
+            min_content_height=EMOJI_LIST_MIN_HEIGHT,
+            propagate_natural_height=True,
+            propagate_natural_width=True,
             vexpand=True
         )
 
@@ -224,7 +224,7 @@ class Picker(Gtk.ApplicationWindow):
         start = time_ns()
 
         self.emoji_list.remove_all()
-        self.emoji_list_widgets = []        
+        self.emoji_list_widgets = []
 
         self.history = get_history()
         filter_for_recents = self.selected_category == 'recents'
@@ -264,8 +264,8 @@ class Picker(Gtk.ApplicationWindow):
                     filter_result = tag_list_contains(emoji['tags'], self.query)
                 else:
                     filter_result = False
-                
-                if not filter_result: 
+
+                if not filter_result:
                     continue
             else:
                 if filter_for_recents:
@@ -278,8 +278,8 @@ class Picker(Gtk.ApplicationWindow):
             self.emoji_button_update_css_classes(emoji_button)
             self.update_emoji_button_skintone(emoji_button, skintone_modifier)
 
-            flowbox_child = create_flowbox_child(emoji_button, 
-                secondary_click_geture_callback=self.flowbox_child_secondary_btn_gesture_end, 
+            flowbox_child = create_flowbox_child(emoji_button,
+                secondary_click_geture_callback=self.flowbox_child_secondary_btn_gesture_end,
                 middle_click_gesture_callback=self.flowbox_child_middle_btn_gesture_end
             )
 
@@ -689,7 +689,7 @@ class Picker(Gtk.ApplicationWindow):
 
     def update_emoji_skintones(self, settings: Gio.Settings, key):
         modifier_settings = settings.get_string(key)
-        
+
         for widget in self.emoji_list_widgets:
             emoji_button = widget.get_child()
             self.update_emoji_button_skintone(emoji_button, modifier_settings)
@@ -711,5 +711,5 @@ class Picker(Gtk.ApplicationWindow):
 
         if apply_border_radius and ('skintones' in widget.emoji_data) and widget.emoji_data['skintones']:
             emoji_button_css.append('emoji-with-skintones')
-            
+
         widget.set_css_classes(emoji_button_css)

--- a/src/lib/lazy_loader.py
+++ b/src/lib/lazy_loader.py
@@ -1,0 +1,120 @@
+# lazy_loader.py
+#
+# Copyright 2025 Nicholas La Roux
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import gi
+import threading
+from typing import Dict, List, Callable, Optional
+from time import time_ns
+
+gi.require_version('GLib', '2.0')
+from gi.repository import GLib
+
+
+class LazyEmojiLoader:
+    """
+    A lazy loader for emoji data that:
+    1. Loads emoji data in background threads
+    2. Calls callbacks when data is ready
+    3. Ensures thread-safe access to loaded data
+    """
+
+    def __init__(self):
+        self.emoji_data: Optional[Dict] = None
+        self.emoji_categories: Optional[Dict] = None
+        self.is_loading = False
+        self.is_loaded = False
+        self.load_callbacks: List[Callable] = []
+        self._load_lock = threading.Lock()
+
+    def load_async(self, callback: Optional[Callable] = None):
+        """
+        Asynchronously load emoji data in a background thread
+
+        Args:
+            callback: Function to call when loading is complete
+        """
+        if self.is_loaded:
+            if callback:
+                callback()
+            return
+
+        if callback:
+            self.load_callbacks.append(callback)
+
+        with self._load_lock:
+            if self.is_loading:
+                return
+            self.is_loading = True
+
+        # Start background loading
+        thread = threading.Thread(target=self._load_emoji_data)
+        thread.daemon = True
+        thread.start()
+
+    def _load_emoji_data(self):
+        """Load emoji data in background thread"""
+        try:
+            start_time = time_ns()
+
+            # Import the large emoji dataset
+            from ..assets.emoji_list import emojis, emoji_categories
+
+            load_time = (time_ns() - start_time) / 1_000_000  # Convert to milliseconds
+
+            with self._load_lock:
+                self.emoji_data = emojis
+                self.emoji_categories = emoji_categories
+                self.is_loaded = True
+                self.is_loading = False
+
+            # Execute callbacks on main thread
+            GLib.idle_add(self._execute_callbacks)
+
+        except Exception as e:
+            print(f"Error loading emoji data: {e}")
+            with self._load_lock:
+                self.is_loading = False
+
+    def _execute_callbacks(self):
+        """Execute all registered callbacks on the main thread"""
+        callbacks_to_execute = self.load_callbacks.copy()
+        self.load_callbacks.clear()
+
+        for callback in callbacks_to_execute:
+            try:
+                callback()
+            except Exception as e:
+                print(f"Error executing emoji load callback: {e}")
+
+    def get_emoji_data(self) -> Optional[Dict]:
+        """Thread-safe access to emoji data"""
+        with self._load_lock:
+            return self.emoji_data
+
+    def get_emoji_categories(self) -> Optional[Dict]:
+        """Thread-safe access to emoji categories"""
+        with self._load_lock:
+            return self.emoji_categories
+
+    def is_currently_loading(self) -> bool:
+        """Check if data is currently being loaded"""
+        return self.is_loading
+
+    def is_data_loaded(self) -> bool:
+        """Check if data has been loaded"""
+        return self.is_loaded
+
+
+# Global lazy loader instance
+emoji_loader = LazyEmojiLoader()

--- a/src/lib/progressive_renderer.py
+++ b/src/lib/progressive_renderer.py
@@ -1,0 +1,145 @@
+# progressive_renderer.py
+#
+# Copyright 2025 Nicholas La Roux
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import gi
+from typing import List, Callable, Optional
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('GLib', '2.0')
+
+from gi.repository import Gtk, GLib
+
+
+class ProgressiveRenderer:
+    """
+    A general-purpose progressive renderer that can render any list of items
+    in batches to avoid blocking the UI. This is useful for large datasets
+    that would otherwise cause UI freezing.
+
+    Can be used for emojis, large lists, search results, etc.
+    """
+
+    def __init__(self, container: Gtk.Widget, batch_size: int = 20, batch_delay: int = 5):
+        """
+        Initialize progressive renderer
+
+        Args:
+            container: The GTK container to add items to
+            batch_size: Number of items to render per batch
+            batch_delay: Milliseconds between batches
+        """
+        self.container = container
+        self.batch_size = batch_size
+        self.batch_delay = batch_delay
+        self.current_batch = 0
+        self.item_queue: List = []
+        self.is_rendering = False
+        self.completion_callback: Optional[Callable] = None
+
+    def render_progressive(self, items: List, item_factory: Callable,
+                          completion_callback: Optional[Callable] = None):
+        """
+        Render items progressively in batches
+
+        Args:
+            items: List of data to render
+            item_factory: Function that creates widgets from data items
+            completion_callback: Callback when all items are rendered
+        """
+        if self.is_rendering:
+            self.stop_rendering()
+
+        self.item_queue = items.copy()
+        self.current_batch = 0
+        self.is_rendering = True
+        self.completion_callback = completion_callback
+
+        # Start rendering first batch immediately
+        GLib.timeout_add(1, self._render_next_batch, item_factory)
+
+    def _render_next_batch(self, item_factory: Callable) -> bool:
+        """Render the next batch of items"""
+        if not self.is_rendering or not self.item_queue:
+            self._finish_rendering()
+            return False
+
+        start_idx = self.current_batch * self.batch_size
+        end_idx = min(start_idx + self.batch_size, len(self.item_queue))
+
+        batch = self.item_queue[start_idx:end_idx]
+
+        # Render this batch
+        for item_data in batch:
+            try:
+                widget = item_factory(item_data)
+                if hasattr(self.container, 'append'):
+                    self.container.append(widget)
+                elif hasattr(self.container, 'add_child'):
+                    self.container.add_child(widget)
+                else:
+                    # Fallback for other container types
+                    self.container.add(widget)
+            except Exception as e:
+                print(f"Error creating widget in progressive renderer: {e}")
+
+        self.current_batch += 1
+
+        # Check if we're done
+        if end_idx >= len(self.item_queue):
+            self._finish_rendering()
+            return False
+
+        # Schedule next batch
+        GLib.timeout_add(self.batch_delay, self._render_next_batch, item_factory)
+        return False
+
+    def _finish_rendering(self):
+        """Clean up and call completion callback"""
+        self.is_rendering = False
+        if self.completion_callback:
+            self.completion_callback()
+            self.completion_callback = None
+
+    def stop_rendering(self):
+        """Stop current rendering operation"""
+        self.is_rendering = False
+        self.item_queue.clear()
+        self.completion_callback = None
+
+    def is_busy(self) -> bool:
+        """Check if currently rendering"""
+        return self.is_rendering
+
+
+class ProgressiveEmojiRenderer(ProgressiveRenderer):
+    """
+    Specialized progressive renderer for emoji widgets.
+    Provides emoji-specific defaults and convenience methods.
+    """
+
+    def __init__(self, container: Gtk.FlowBox):
+        # Emoji-specific defaults: smaller batches, faster rendering
+        super().__init__(container, batch_size=20, batch_delay=5)
+
+    def render_emojis_progressive(self, emoji_list: List, emoji_factory: Callable,
+                                 completion_callback: Optional[Callable] = None):
+        """
+        Convenience method for rendering emojis specifically
+
+        Args:
+            emoji_list: List of emoji data to render
+            emoji_factory: Function that creates emoji button widgets
+            completion_callback: Callback when all emojis are rendered
+        """
+        return self.render_progressive(emoji_list, emoji_factory, completion_callback)

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,10 @@ class Smile(Adw.Application):
     def do_startup(self):
         Adw.Application.do_startup(self)
 
+        # Start loading emoji data as early as possible
+        from .lib.lazy_loader import emoji_loader
+        emoji_loader.load_async()
+
         css_provider = Gtk.CssProvider()
         css_provider.load_from_resource('/it/mijorus/smile/assets/style.css')
         Gtk.StyleContext.add_provider_for_display(Gdk.Display.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)


### PR DESCRIPTION
> [!IMPORTANT]  
> Should merge https://github.com/mijorus/smile/pull/120 first as this is built on top of such. This PR's proposed changes are just those in https://github.com/mijorus/smile/pull/121/commits/4bdd993f751571192a590a6f3fcfca55a7e43b53.

### What does this PR do?

This PR aims to speed up the launch of Smile from around 2-3 seconds to under a second via offloading emoji loading to a new background process based loader and progressively rendering the massive emoji list via a new batch-based progressive renderer while also adding a loading state to conceal the background loading on slower systems.

:information_source: Full transparency, I did use LLMs (mainly Claude and a bit of Gemini) to implement the first version of most these changes as I'm both unfamiliar with GTK/Flatpak/etc. and Python¹. That said, I have manually gone through everything several times and iterated as I felt necessary.

¹ More of a Ruby/Rails/web dev myself but I really enjoy this app and GNOME so I'd like to improve it! :rocket: 

Resolves https://github.com/mijorus/smile/issues/114

### :tophat: Tophatting/checking app :tophat: 

**Before** (current app)

https://github.com/user-attachments/assets/9422858a-e367-45ab-bf8d-332033828d15

**After** (this PR local build)

https://github.com/user-attachments/assets/b1ac16bc-b3d2-431c-ba23-28f3b05c9fd3

### :tophat: Tophatting/checking loading :tophat: 

https://github.com/user-attachments/assets/deb2106b-4435-4ae5-995a-cc9d3480d80d