### PR TITLE
Fix `0.55.0: {'ExternalProgram.path'}` deprecated feature warning

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ gnome.compile_resources('smile',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)


### PR DESCRIPTION
### What does this PR do?

Updates the `meson.build` to use `full_path()` instead of `path()` as the latter is deprecated.

### :tophat: Tophatting/checking build :tophat: 

**Before**

<img width="2880" height="1920" alt="Screenshot From 2025-08-11 10-54-37" src="https://github.com/user-attachments/assets/b9c35c98-4c48-4131-85d4-10bde27647ea" />

**After**

<img width="2880" height="1920" alt="Screenshot From 2025-08-11 10-54-48" src="https://github.com/user-attachments/assets/ff73312c-d4e1-454b-8a66-b3a3fe7d47ec" />

### :tophat: Tophatting/checking app :tophat: 

<img width="2880" height="1920" alt="Screenshot From 2025-08-11 10-55-00" src="https://github.com/user-attachments/assets/287439af-fd0c-4080-9d51-91699d8e8727" />