### PR TITLE
Update README to state correct required GNOME packages, from 44 to 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Awesome resources that made Smile possible:
 You will need:
 - flatpak
 - flatpak-builder
-- org.gnome.Platform 44
-- org.gnome.Sdk 44
+- org.gnome.Platform 48
+- org.gnome.Sdk 48
 - pango devel kit
 
 ```sh


### PR DESCRIPTION
Simply correcting the README to the expected version of GNOME platform and SDK re: the following.

https://github.com/mijorus/smile/blob/16424d3ac0d7716bae24169880bcbcd25cb011fa/it.mijorus.smile.json#L4