### PR TITLE
Require Meson >= v1.0.0 for long term project health

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('smile',
     version: '2.12.2',
-    meson_version: '>= 0.59.0',
+    meson_version: '>= 1.0.0',
     default_options: [ 'warning_level=2', ],
 )
 


### PR DESCRIPTION
### What does this PR do?

Proposing we bump the Meson requirement to v1.0.0. Not only is the current required version ~4 years old but getting on v1.0.0 and up would be a nice win for long term project health.

For reference
- [v0.59.0](https://github.com/mesonbuild/meson/releases/tag/0.59.0) came out in July 2021 (current)
- [v1.0.0](https://github.com/mesonbuild/meson/releases/tag/1.0.0) came out in December 2022 (proposed)
- [v1.10.0](https://github.com/mesonbuild/meson/releases/tag/1.10.0) came out in December 2025
- [v1.10.2](https://github.com/mesonbuild/meson/releases/tag/1.10.2) came out in January 2026 (latest)

### :tophat: Tophatting/checking app :tophat: 

https://github.com/user-attachments/assets/ad5ad82c-c480-4bd2-9175-ed69b15afcf4