### PR TITLE
Show emoji annotation as tooltip

### DIFF
--- a/src/lib/widget_utils.py
+++ b/src/lib/widget_utils.py
@@ -33,6 +33,7 @@ def create_flowbox_child(emoji_button: Gtk.Button, secondary_click_geture_callba
 
 def create_emoji_button(emoji_data: dict, click_handler=None) -> Gtk.Button:
     emoji_button = Gtk.Button(label=emoji_data['emoji'], can_focus=False)
+    emoji_button.set_tooltip_text(emoji_data.get('annotation', ''))
     emoji_button.emoji_data = emoji_data
     emoji_button.hexcode = emoji_data['hexcode']
     emoji_button.base_skintone_widget = None


### PR DESCRIPTION
I often find myself wondering about the name/annotation of a given emoji before deciding to use it. It would be nice if these could appear in tooltips when hovering.
I haven't tested this proposed change as I couldn't get the project running on my dev machine (I'm not a Python or Flatpak dev), but this PR should get the idea across.
No doubt there will be localization implications also.