### PR TITLE
Upgrade GNOME runtime from 48 to 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Awesome resources that made Smile possible:
 You will need:
 - flatpak
 - flatpak-builder
-- org.gnome.Platform 48
-- org.gnome.Sdk 48
+- org.gnome.Platform 49
+- org.gnome.Sdk 49
 - pango devel kit
 
 ```sh

--- a/it.mijorus.smile.json
+++ b/it.mijorus.smile.json
@@ -1,7 +1,7 @@
 {
     "id": "it.mijorus.smile",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "smile",
     "finish-args": [


### PR DESCRIPTION
Quick and simple upgrade from GNOME runtime 48 to 49, release notes below.

https://release.gnome.org/49/developers/index.html

:tophat: :tophat: :tophat: :tophat: :tophat:

https://github.com/user-attachments/assets/da3bcce3-5a2f-4593-b6f7-4e4d85f9be61

Note, one of the changes in GNOME 49・Libadwaita 1.8 is the deprecation of `GtkShortcutsWindow` in favor of `AdwShortcutsDialog`. See the deprecation context below. I've logged an issue to track this migration: https://github.com/mijorus/smile/issues/135.

> [AdwShortcutsDialog](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ShortcutsDialog.html) provides a modern replacement for the now deprecated GtkShortcutsWindow, and is the recommended method for apps to document their keyboard shortcuts. The new widget is adaptive and benefits from integrated search. Additionally, AdwShortcutLabel has been introduced as a replacement for GtkShortcutLabel, which can be used to show keyboard shortcuts in other interfaces.