### PR TITLE
Upgrade GNOME runtime from 49 to 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Awesome resources that made Smile possible:
 You will need:
 - flatpak
 - flatpak-builder
-- org.gnome.Platform 49
-- org.gnome.Sdk 49
+- org.gnome.Platform 50
+- org.gnome.Sdk 50
 - pango devel kit
 
 ```sh

--- a/it.mijorus.smile.json
+++ b/it.mijorus.smile.json
@@ -1,7 +1,7 @@
 {
     "id": "it.mijorus.smile",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "smile",
     "finish-args": [


### PR DESCRIPTION
Small PR to bump the GNOME runtime form 49 to 50 now that that's available.

https://discourse.gnome.org/t/introducing-gnome-50/34400
https://gitlab.gnome.org/GNOME/gnome-build-meta/-/releases/50.0