### PR TITLE
Added a settings option to default to recent tab at startup

### DIFF
--- a/data/it.mijorus.smile.gschema.xml
+++ b/data/it.mijorus.smile.gschema.xml
@@ -44,5 +44,8 @@
         <key name="mouse-multi-select" type="b">
             <default>false</default>
         </key>
+	<key name="default-to-recent" type="b">
+            <default>false</default>
+        </key>
     </schema>
 </schemalist>

--- a/src/Picker.py
+++ b/src/Picker.py
@@ -129,6 +129,13 @@ class Picker(Gtk.ApplicationWindow):
         self.refresh_emoji_list()
         self.category_picker_widgets: list[Gtk.Button] = []
         self.category_picker = self.create_category_picker()
+        
+        if self.settings.get_boolean('default-to-recent'):
+            self.set_active_category('recents')
+            self.selected_category = 'recents'
+            self.selected_category_index = 0
+
+        self.refresh_emoji_list()
 
         scrolled_emoji_window = Gtk.ScrolledWindow(
             min_content_height=EMOJI_LIST_MIN_HEIGHT,
@@ -175,6 +182,15 @@ class Picker(Gtk.ApplicationWindow):
         self.overlay.set_child(self.viewport_box)
 
         self.set_active_category('smileys-emotion')
+        
+        initial_category = (
+            'recents'
+            if self.settings.get_boolean('default-to-recent')
+            else 'smileys-emotion'
+        )
+
+        self.selected_category = initial_category
+        self.set_active_category(initial_category)
 
         self.set_child(self.overlay)
         self.search_entry.grab_focus()

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -75,6 +75,7 @@ class Settings(Adw.PreferencesWindow):
         customization_group = Adw.PreferencesGroup(title=_('Customization'))
         customization_group.add(self.create_modifiers_combo_boxes())
         customization_group.add(self.create_emoji_sizes_combo_boxes())
+        customization_group.add(self.create_boolean_settings_entry(_('Set default tab to recent'), 'default-to-recent', '',))
 
         self.localized_tags_group = Adw.PreferencesGroup(title=_('Localized tags'))
         self.localized_tags_group.add(


### PR DESCRIPTION
This PR adds a settings option under Preferences --> Customization --> Set default tab to recent to open the Recent tab by default in the emoji picker.

Changes:
- Added new GSettings key: default-to-recent
- Added settings toggle in Preferences UI
- Updated Picker logic to respect setting on startup

Behavior:
- When enabled, emoji picker opens on recent tab
- When disabled, default behavior (Smileys & Emotion) is preserved

Fixes: 
- #136 
- #131 
- #81