### PR TITLE
Migrate from deprecated `GtkShortcutsWindow` to `AdwShortcutsDialog`, moving mouse controls into their own dialog

### DIFF
--- a/src/MouseControlsDialog.py
+++ b/src/MouseControlsDialog.py
@@ -1,0 +1,26 @@
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import Gtk, Gio, Adw  # noqa
+
+
+class MouseControlsDialog():
+    def __init__(self):
+        Adw.init()
+        builder = Gtk.Builder()
+        builder.add_from_resource('/it/mijorus/smile/ui/mouse_controls.ui')
+        self.dialog = builder.get_object('mouse_controls_dialog')
+
+        settings = Gio.Settings.new('it.mijorus.smile')
+
+        add_em_to_selection_label = _('Add an emoji to selection')
+        copy_quit_label = _('Copy the selected emoji and hide the window')
+
+        mouse_multi_select = settings.get_boolean('mouse-multi-select')
+        builder.get_object('shift-left-click-row').set_title(copy_quit_label if mouse_multi_select else add_em_to_selection_label)
+        builder.get_object('left-click-row').set_title(add_em_to_selection_label if mouse_multi_select else copy_quit_label)
+
+    def open(self, parent=None):
+        self.dialog.present(parent)

--- a/src/Picker.py
+++ b/src/Picker.py
@@ -390,7 +390,7 @@ class Picker(Gtk.ApplicationWindow):
 
             elif keyval == Gdk.KEY_question:
                 shortcut_window = ShortcutsWindow()
-                shortcut_window.open()
+                shortcut_window.open(self)
 
             elif (keyval == Gdk.KEY_Return):
                 if self.selection:

--- a/src/ShortcutsWindow.py
+++ b/src/ShortcutsWindow.py
@@ -1,15 +1,10 @@
-import sys
 import gi
-import time
-import os
-import csv
-import re
-from .assets.emoji_list import emojis
 
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 
-from gi.repository import Gtk, Gio, Gdk, Adw  # noqa
+from gi.repository import Gtk, Adw  # noqa
+
 
 class ShortcutsWindow():
     def __init__(self):
@@ -18,15 +13,5 @@ class ShortcutsWindow():
         builder.add_from_resource('/it/mijorus/smile/ui/shortcuts.ui')
         self.shortcut_window = builder.get_object('shortcuts')
 
-        settings = Gio.Settings.new('it.mijorus.smile')
-
-        add_em_to_selection_label = _('Add an emoji to selection')
-        copy_quit_label = _('Copy the selected emoji and hide the window')
-
-        mouse_multi_select = settings.get_boolean('mouse-multi-select')
-        builder.get_object('shift-left-click-item').set_title(copy_quit_label if mouse_multi_select else add_em_to_selection_label)
-        builder.get_object('left-click-item').set_title(add_em_to_selection_label if mouse_multi_select else copy_quit_label)
-
     def open(self, parent=None):
         self.shortcut_window.present(parent)
-

--- a/src/ShortcutsWindow.py
+++ b/src/ShortcutsWindow.py
@@ -7,15 +7,16 @@ import re
 from .assets.emoji_list import emojis
 
 gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
 
-from gi.repository import Gtk, Gio, Gdk  # noqa
+from gi.repository import Gtk, Gio, Gdk, Adw  # noqa
 
 class ShortcutsWindow():
     def __init__(self):
+        Adw.init()
         builder = Gtk.Builder()
         builder.add_from_resource('/it/mijorus/smile/ui/shortcuts.ui')
         self.shortcut_window = builder.get_object('shortcuts')
-        self.shortcut_window.set_default_size(600, 400)
 
         settings = Gio.Settings.new('it.mijorus.smile')
 
@@ -23,8 +24,9 @@ class ShortcutsWindow():
         copy_quit_label = _('Copy the selected emoji and hide the window')
 
         mouse_multi_select = settings.get_boolean('mouse-multi-select')
-        builder.get_object('shift-left-click-label').set_label(copy_quit_label if mouse_multi_select else add_em_to_selection_label)
-        builder.get_object('left-click-label').set_label(add_em_to_selection_label if mouse_multi_select else copy_quit_label)
+        builder.get_object('shift-left-click-item').set_title(copy_quit_label if mouse_multi_select else add_em_to_selection_label)
+        builder.get_object('left-click-item').set_title(add_em_to_selection_label if mouse_multi_select else copy_quit_label)
 
-    def open(self):
-        self.shortcut_window.present()
+    def open(self, parent=None):
+        self.shortcut_window.present(parent)
+

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import gi
 from .utils import make_option, portal
 from .Picker import Picker
 from .ShortcutsWindow import ShortcutsWindow
+from .MouseControlsDialog import MouseControlsDialog
 from .Settings import Settings
 from .components.UpdateDialog import UpdateDialog
 from .lib.DbusService import DbusService, GNOME_EXTENSION_LINK
@@ -58,6 +59,7 @@ class Smile(Adw.Application):
 
             self.create_action("preferences", lambda w, e: self.on_preferences_action())
             self.create_action("open_shortcuts", lambda w, e: ShortcutsWindow().open(self.window))
+            self.create_action("open_mouse_controls", lambda w, e: MouseControlsDialog().open(self.window))
             self.create_action("open_changelog", lambda w, e: Gtk.UriLauncher.new('https://smile.mijorus.it/changelog').launch())
             self.create_action("translate", lambda w, e: Gtk.UriLauncher.new('https://github.com/mijorus/smile/tree/master/po').launch())
             self.create_action("gnome_extension", lambda w, e: Gtk.UriLauncher.new(GNOME_EXTENSION_LINK).launch())

--- a/src/main.py
+++ b/src/main.py
@@ -57,7 +57,7 @@ class Smile(Adw.Application):
             self.window = Picker(application=self)
 
             self.create_action("preferences", lambda w, e: self.on_preferences_action())
-            self.create_action("open_shortcuts", lambda w, e: ShortcutsWindow().open())
+            self.create_action("open_shortcuts", lambda w, e: ShortcutsWindow().open(self.window))
             self.create_action("open_changelog", lambda w, e: Gtk.UriLauncher.new('https://smile.mijorus.it/changelog').launch())
             self.create_action("translate", lambda w, e: Gtk.UriLauncher.new('https://github.com/mijorus/smile/tree/master/po').launch())
             self.create_action("gnome_extension", lambda w, e: Gtk.UriLauncher.new(GNOME_EXTENSION_LINK).launch())

--- a/src/smile.gresource.xml
+++ b/src/smile.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
     <gresource prefix="/it/mijorus/smile">
         <file>ui/shortcuts.ui</file>
+        <file>ui/mouse_controls.ui</file>
         <file>ui/menu.ui</file>
         <file>assets/style.css</file>
         <file>assets/smile.autostart.desktop</file>

--- a/src/ui/menu.ui
+++ b/src/ui/menu.ui
@@ -7,6 +7,10 @@
                 <attribute name="action">app.preferences</attribute>
             </item>
             <item>
+                <attribute name="label" translatable="yes">Mouse Controls</attribute>
+                <attribute name="action">app.open_mouse_controls</attribute>
+            </item>
+            <item>
                 <attribute name="label" translatable="yes">Shortcuts</attribute>
                 <attribute name="action">app.open_shortcuts</attribute>
             </item>

--- a/src/ui/mouse_controls.ui
+++ b/src/ui/mouse_controls.ui
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <object class="AdwDialog" id="mouse_controls_dialog">
+        <property name="title" translatable="yes">Mouse Controls</property>
+        <property name="content-width">500</property>
+        <child>
+            <object class="AdwToolbarView">
+                <child type="top">
+                    <object class="AdwHeaderBar"/>
+                </child>
+                <property name="content">
+                    <object class="AdwPreferencesPage">
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <child>
+                                    <object class="AdwActionRow" id="left-click-row">
+                                        <property name="title" translatable="yes">Copy the selected emoji and hide the window</property>
+                                        <child type="suffix">
+                                            <object class="GtkLabel">
+                                                <property name="label">Left Click</property>
+                                                <property name="margin-start">24</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="AdwActionRow">
+                                        <property name="title" translatable="yes">Open the skintone selector (if available)</property>
+                                        <child type="suffix">
+                                            <object class="GtkLabel">
+                                                <property name="label">Right Click</property>
+                                                <property name="margin-start">24</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="AdwActionRow">
+                                        <property name="title" translatable="yes">Add a custom tag</property>
+                                        <child type="suffix">
+                                            <object class="GtkLabel">
+                                                <property name="label">Middle Click</property>
+                                                <property name="margin-start">24</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="AdwActionRow" id="shift-left-click-row">
+                                        <property name="title" translatable="yes">Add an emoji to selection</property>
+                                        <child type="suffix">
+                                            <object class="GtkBox">
+                                                <property name="spacing">4</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">24</property>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label">Shift</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label">+</property>
+                                                        <style>
+                                                            <class name="dimmed"/>
+                                                        </style>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label">Left Click</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                    </object>
+                </property>
+            </object>
+        </child>
+    </object>
+</interface>

--- a/src/ui/shortcuts.ui
+++ b/src/ui/shortcuts.ui
@@ -1,183 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <object class="GtkShortcutsWindow" id="shortcuts">
-        <property name="modal">1</property>
+    <object class="AdwShortcutsDialog" id="shortcuts">
         <child>
-            <object class="GtkShortcutsSection">
-                <property name="visible">True</property>
-                <property name="section-name">shortcuts</property>
+            <object class="AdwShortcutsSection">
+                <property name="title" translatable="yes">Mouse</property>
                 <child>
-                    <object class="GtkShortcutsGroup">
-                        <property name="visible">True</property>
-                        <property name="title" translatable="yes">Mouse</property>
-                        <child>
-                            <object class="GtkBox">
-                                <child>
-                                    <object class="GtkShortcutLabel">
-                                        <property name="width-request">190</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label">Left Click</property>
-                                                <property name="css-classes">keycap</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object id="left-click-label" class="GtkLabel">
-                                        <property name="label" translatable="yes"></property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <child>
-                                    <object class="GtkShortcutLabel">
-                                        <property name="width-request">190</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label">Right Click</property>
-                                                <property name="css-classes">keycap</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">Open the skintone selector (if available)</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <child>
-                                    <object class="GtkShortcutLabel">
-                                        <property name="width-request">190</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label">Middle Click</property>
-                                                <property name="css-classes">keycap</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">Add a custom tag</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <child>
-                                    <object class="GtkShortcutLabel">
-                                        <property name="width-request">190</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label">Shift</property>
-                                                <property name="css-classes">keycap</property>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label">+</property>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label">Left Click</property>
-                                                <property name="css-classes">keycap</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object id="shift-left-click-label" class="GtkLabel">
-                                        <property name="label" translatable="yes"></property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
+                    <object class="AdwShortcutsItem" id="left-click-item">
+                        <property name="accelerator">Pointer_Button1</property>
+                        <property name="title" translatable="yes">Add an emoji to selection</property>
                     </object>
                 </child>
                 <child>
-                    <object class="GtkShortcutsGroup">
-                        <property name="visible">True</property>
-                        <property name="title" translatable="yes">Keyboard</property>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">Return</property>
-                                <property name="title" translatable="yes">Copy the selected emoji and hide the window (When an emoji is highlighted)</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">Return</property>
-                                <property name="title" translatable="yes">Copy first emoji and hide the window (When using the search bar)</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;alt&gt;Right</property>
-                                <property name="title" translatable="yes">Show the category on the right</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;alt&gt;Left</property>
-                                <property name="title" translatable="yes">Show the category on the left</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;shift&gt;Return</property>
-                                <property name="title" translatable="yes">Add an emoji to selection</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;shift&gt;BackSpace</property>
-                                <property name="title" translatable="yes">Remove the last emoji from the selection</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;ctrl&gt;Return</property>
-                                <property name="title" translatable="yes">Copy the selection and hide the window, without the highlighted emoji</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;alt&gt;E</property>
-                                <property name="title" translatable="yes">Open the skintone selector (if available)</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;alt&gt;T</property>
-                                <property name="title" translatable="yes">Add a custom tag</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkShortcutsShortcut">
-                                <property name="visible">True</property>
-                                <property name="accelerator">&lt;ctrl&gt;q</property>
-                                <property name="title" translatable="yes">Quit the application</property>
-                            </object>
-                        </child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">Pointer_Button3</property>
+                        <property name="title" translatable="yes">Open the skintone selector (if available)</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">Pointer_Button2</property>
+                        <property name="title" translatable="yes">Add a custom tag</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem" id="shift-left-click-item">
+                        <property name="accelerator">&lt;Shift&gt;Pointer_Button1</property>
+                        <property name="title" translatable="yes">Copy the selected emoji and hide the window</property>
+                    </object>
+                </child>
+            </object>
+        </child>
+        <child>
+            <object class="AdwShortcutsSection">
+                <property name="title" translatable="yes">Keyboard</property>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">Return</property>
+                        <property name="title" translatable="yes">Copy the selected emoji and hide the window (When an emoji is highlighted)</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">Return</property>
+                        <property name="title" translatable="yes">Copy first emoji and hide the window (When using the search bar)</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Alt&gt;Right</property>
+                        <property name="title" translatable="yes">Show the category on the right</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Alt&gt;Left</property>
+                        <property name="title" translatable="yes">Show the category on the left</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Shift&gt;Return</property>
+                        <property name="title" translatable="yes">Add an emoji to selection</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Shift&gt;BackSpace</property>
+                        <property name="title" translatable="yes">Remove the last emoji from the selection</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Ctrl&gt;Return</property>
+                        <property name="title" translatable="yes">Copy the selection and hide the window, without the highlighted emoji</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Alt&gt;E</property>
+                        <property name="title" translatable="yes">Open the skintone selector (if available)</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Alt&gt;T</property>
+                        <property name="title" translatable="yes">Add a custom tag</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwShortcutsItem">
+                        <property name="accelerator">&lt;Ctrl&gt;q</property>
+                        <property name="title" translatable="yes">Quit the application</property>
                     </object>
                 </child>
             </object>

--- a/src/ui/shortcuts.ui
+++ b/src/ui/shortcuts.ui
@@ -3,46 +3,16 @@
     <object class="AdwShortcutsDialog" id="shortcuts">
         <child>
             <object class="AdwShortcutsSection">
-                <property name="title" translatable="yes">Mouse</property>
-                <child>
-                    <object class="AdwShortcutsItem" id="left-click-item">
-                        <property name="accelerator">Pointer_Button1</property>
-                        <property name="title" translatable="yes">Add an emoji to selection</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="AdwShortcutsItem">
-                        <property name="accelerator">Pointer_Button3</property>
-                        <property name="title" translatable="yes">Open the skintone selector (if available)</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="AdwShortcutsItem">
-                        <property name="accelerator">Pointer_Button2</property>
-                        <property name="title" translatable="yes">Add a custom tag</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="AdwShortcutsItem" id="shift-left-click-item">
-                        <property name="accelerator">&lt;Shift&gt;Pointer_Button1</property>
-                        <property name="title" translatable="yes">Copy the selected emoji and hide the window</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-        <child>
-            <object class="AdwShortcutsSection">
-                <property name="title" translatable="yes">Keyboard</property>
                 <child>
                     <object class="AdwShortcutsItem">
                         <property name="accelerator">Return</property>
-                        <property name="title" translatable="yes">Copy the selected emoji and hide the window (When an emoji is highlighted)</property>
+                        <property name="title" translatable="yes">Copy selected emoji and hide window (when emoji highlighted)</property>
                     </object>
                 </child>
                 <child>
                     <object class="AdwShortcutsItem">
                         <property name="accelerator">Return</property>
-                        <property name="title" translatable="yes">Copy first emoji and hide the window (When using the search bar)</property>
+                        <property name="title" translatable="yes">Copy first emoji and hide window (when using search bar)</property>
                     </object>
                 </child>
                 <child>
@@ -72,7 +42,7 @@
                 <child>
                     <object class="AdwShortcutsItem">
                         <property name="accelerator">&lt;Ctrl&gt;Return</property>
-                        <property name="title" translatable="yes">Copy the selection and hide the window, without the highlighted emoji</property>
+                        <property name="title" translatable="yes">Copy selection and hide window, without highlighted emoji</property>
                     </object>
                 </child>
                 <child>


### PR DESCRIPTION
## Description

Proposing we migrate from the deprecated `GtkShortcutsWindow` to `AdwShortcutsDialog` and in doing so move the mouse controls out of the shortcuts dialog and into a new `Mouse Controls` dialog.

> `AdwShortcutsDialog` provides a modern replacement for the now deprecated `GtkShortcutsWindow`

- **Migrated to `AdwShortcutsDialog`:** Replaced deprecated `GtkShortcutsWindow` with Libadwaita's `AdwShortcutsDialog` for keyboard shortcuts.
- **Created dedicated Mouse Controls dialog:** Created a separate "Mouse Controls" dialog (`AdwDialog` + `AdwActionRow`) accessible from the main menu.

Documentation: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ShortcutsDialog.html

Resolves https://github.com/mijorus/smile/issues/135

## Why mouse controls were moved out

`AdwShortcutsItem` is strictly designed for keyboard accelerators. When passed pointer button keyvals, GTK formats them as raw string representations (`Pointer_Button1`, `Pointer_Button2`):

<img width="1684" height="2114" alt="Screenshot From 2026-07-26 13-17-40" src="https://github.com/user-attachments/assets/409ed754-53c0-4807-892c-a6109faad7cb" />

Overriding these labels in `AdwShortcutsDialog` required fragile runtime widget-tree hacks. Meanwhile moving mouse controls into their own dialog:
1. Avoids widget-tree hacks.
2. Restores clean labels ("Left Click", "Right Click", "Middle Click", "Shift + Left Click").
3. Logically separates mouse interactions from keyboard shortcuts.
4. Helps us avoid the "shortcuts window being the full height of the screen even on a 1080p screen because there are so many entries" issue. See below:

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/b0f293fc-ba53-44a3-9955-576240c5269c" />

## Testing

https://github.com/user-attachments/assets/f438f2ee-e29d-45fb-8ba1-eae933c0039c