### PR TITLE
Improve gitignore ignoring of pycache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ build
 flatpak-pip-generator.py
 problematic_emojis.cpython*
 run.sh
-src/lib/__pycache__
-src/lib/__pycache__
+__pycache__/
 .glade~
 install.sh
 


### PR DESCRIPTION
Proposing we improve the ignoring of `pycache` files as I recently ran into some being added while working on https://github.com/mijorus/smile/pull/155.

Some light testing below. This new ignore should match all `__pycache__` at any depth.

<img width="3840" height="2096" alt="Screenshot From 2026-07-26 20-02-01" src="https://github.com/user-attachments/assets/ba7b85b0-f370-4c4c-9939-bba253715ad5" />